### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: 🧪 CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/omegaalfa/JwToken/security/code-scanning/4](https://github.com/omegaalfa/JwToken/security/code-scanning/4)

To fix the problem, explicitly set `GITHUB_TOKEN` permissions in the workflow to the minimum needed. Since this job only checks out code, installs dependencies, runs static analysis, tests, and `composer audit`, it only needs read access to the repository contents. No steps modify PRs, push commits, publish releases, or interact with other resources that would require additional scopes.

The best fix, without changing existing functionality, is to add a `permissions` block with `contents: read`. This can be placed either at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs, or specifically under the `test` job. Given the CodeQL warning about the job, placing it at the root is clean and also protects any future jobs. Concretely, in `.github/workflows/ci.yaml` add:

```yaml
permissions:
  contents: read
```

right after the `name: 🧪 CI` line (line 1) and before the `on:` block (line 3). No additional imports or methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
